### PR TITLE
Handle multiple items with same search text

### DIFF
--- a/WpfToolkit/DataVisualization/System.Windows.Controls.DataVisualization.Toolkit.XML
+++ b/WpfToolkit/DataVisualization/System.Windows.Controls.DataVisualization.Toolkit.XML
@@ -12151,35 +12151,5 @@
             Gets or sets the list of event listeners.
             </summary>
         </member>
-        <member name="T:XamlGeneratedNamespace.GeneratedInternalTypeHelper">
-            <summary>
-            GeneratedInternalTypeHelper
-            </summary>
-        </member>
-        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.CreateInstance(System.Type,System.Globalization.CultureInfo)">
-            <summary>
-            CreateInstance
-            </summary>
-        </member>
-        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.GetPropertyValue(System.Reflection.PropertyInfo,System.Object,System.Globalization.CultureInfo)">
-            <summary>
-            GetPropertyValue
-            </summary>
-        </member>
-        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.SetPropertyValue(System.Reflection.PropertyInfo,System.Object,System.Object,System.Globalization.CultureInfo)">
-            <summary>
-            SetPropertyValue
-            </summary>
-        </member>
-        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.CreateDelegate(System.Type,System.Object,System.String)">
-            <summary>
-            CreateDelegate
-            </summary>
-        </member>
-        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.AddEventHandler(System.Reflection.EventInfo,System.Object,System.Delegate)">
-            <summary>
-            AddEventHandler
-            </summary>
-        </member>
     </members>
 </doc>

--- a/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
+++ b/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
@@ -2213,6 +2213,25 @@ namespace System.Windows.Controls
             UpdateTextCompletion(_userCalledPopulate);
         }
 
+        private void UpdateTextCompletion(object selectedItem)
+        {
+            if (SelectedItem != selectedItem)
+            {
+                _skipSelectedItemTextUpdate = true;
+            }
+            SelectedItem = selectedItem;
+
+            // Restore updates for TextSelection
+            if (_ignoreTextSelectionChange)
+            {
+                _ignoreTextSelectionChange = false;
+                if (TextBox != null)
+                {
+                    _textSelectionStart = TextBox.SelectionStart;
+                }
+            }
+        }
+
         /// <summary>
         /// Performs text completion, if enabled, and a lookup on the underlying
         /// item values for an exact match. Will update the SelectedItem value.
@@ -2282,22 +2301,7 @@ namespace System.Windows.Controls
             }
 
             // Update the selected item property
-
-            if (SelectedItem != newSelectedItem)
-            {
-                _skipSelectedItemTextUpdate = true;
-            }
-            SelectedItem = newSelectedItem;
-
-            // Restore updates for TextSelection
-            if (_ignoreTextSelectionChange)
-            {
-                _ignoreTextSelectionChange = false;
-                if (TextBox != null)
-                {
-                    _textSelectionStart = TextBox.SelectionStart;
-                }
-            }
+            UpdateTextCompletion(newSelectedItem);
         }
 
         /// <summary>
@@ -2537,8 +2541,16 @@ namespace System.Windows.Controls
         {
             IsDropDownOpen = false;
 
-            // Completion will update the selected value
-            UpdateTextCompletion(false);
+            ISelectionAdapter selectionAdapter = (sender as ISelectionAdapter);
+
+            if (selectionAdapter != null)
+            {
+                UpdateTextCompletion(selectionAdapter.SelectedItem);
+            }
+            else
+            {
+                UpdateTextCompletion(false);
+            }
 
             // Text should not be selected
             if (TextBox != null)

--- a/WpfToolkit/Layout/System.Windows.Controls.Layout.Toolkit.XML
+++ b/WpfToolkit/Layout/System.Windows.Controls.Layout.Toolkit.XML
@@ -3542,7 +3542,7 @@
             Changing this bounds is expensive since it has to re-divide the entire thing - like a re-hash operation.
             </summary>
         </member>
-        <!-- Ungültiger XML-Kommentar wurde für den Member "T:System.Collections.Generic.PriorityQuadTree`1.QuadNode" ignoriert -->
+        <!-- Badly formed XML comment ignored for member "T:System.Collections.Generic.PriorityQuadTree`1.QuadNode" -->
         <member name="M:System.Collections.Generic.PriorityQuadTree`1.QuadNode.#ctor(`0,System.Windows.Rect,System.Double)">
             <summary>
             Construct new QuadNode to wrap the given node with given bounds.
@@ -4312,8 +4312,8 @@
             The exact area that is displayed can be determined by the <see cref="P:System.Windows.Controls.ZoomableCanvas.ActualViewbox"/> property in this case.
             </remarks>
         </member>
-        <!-- Ungültiger XML-Kommentar wurde für den Member "P:System.Windows.Controls.ZoomableCanvas.Offset" ignoriert -->
-        <!-- Ungültiger XML-Kommentar wurde für den Member "P:System.Windows.Controls.ZoomableCanvas.Scale" ignoriert -->
+        <!-- Badly formed XML comment ignored for member "P:System.Windows.Controls.ZoomableCanvas.Offset" -->
+        <!-- Badly formed XML comment ignored for member "P:System.Windows.Controls.ZoomableCanvas.Scale" -->
         <member name="P:System.Windows.Controls.ZoomableCanvas.RealizationLimit">
             <summary>
             Gets or sets the maximum number of elements that will be instantiated on the canvas when <see cref="!:IsVirtualizing"/> is set to <see cref="!:true"/>.


### PR DESCRIPTION
When ISelectionAdapter.Commit was completed the code used
UpdateTextCompletion to find the first item with a matching string. If
the items source contained multiple items with a matching string, you
only ever got the first item, regardless of which one you selected in
the SelectionAdapter.
This change uses the specific item selected in the SelectionAdapter
instead of trying to "find" a matching item.