### PR TITLE
_adapter.SelectedItem is sometimes stale. Utilise the SelectedItem in the event instead

### DIFF
--- a/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
+++ b/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
@@ -2632,7 +2632,14 @@ namespace System.Windows.Controls
         /// <param name="e">The selection changed event data.</param>
         private void OnAdapterSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            SelectedItem = _adapter.SelectedItem;
+            if (e.AddedItems.Count == 1)
+            {
+                SelectedItem = e.AddedItems[0];
+            }
+            else
+            {
+                SelectedItem = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I have found an issue when utilising a custom search (it may happen in other circumstances too) and a view model bound to the selecteditem. 

- User types in to search
- Search results are returned
- User selects an item, the view model is updated with said selected item.
- <user does something in the GUI, in this case a dialog box opens>
- User comes back and does a second search
- Search results are returned
- User selects an item, the view model is updated, but with the item they selected the last time.

Unfortunately I cannot work out why exactly this is. It appears to be slightly interesting behaviour from the SelectionChanged on the ItemsControl still returns the old value. It appears to be a framework bug (from a quick google)

The correct way to resolve this is to utilise the args of the event, to get the newly SelectedItem, from added items. 

In this case we should only have one item (as you can only select one item), so we either set the item, OR we clear the item. 