### PR TITLE
Select item in SelectionAdapter when autocomplete happens.

### DIFF
--- a/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
+++ b/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
@@ -2323,6 +2323,7 @@ namespace System.Windows.Controls
                 _skipSelectedItemTextUpdate = true;
             }
             SelectedItem = selectedItem;
+            SelectionAdapter.SelectedItem = selectedItem;
 
             // Restore updates for TextSelection
             if (_ignoreTextSelectionChange)


### PR DESCRIPTION
 Fixes a bug whereby if the user presses enter the SelectedItem property is not updated.