### PR TITLE
Use the correct event when adding handler in DropDownOpening

### DIFF
--- a/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
+++ b/WpfToolkit/Input/AutoCompleteBox/System/Windows/Controls/AutoCompleteBox.cs
@@ -3,7 +3,6 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993] for details.
 // All other rights reserved.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -15,7 +14,6 @@ using System.Windows.Automation.Peers;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
-using System.Windows.Interop;
 using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -1301,8 +1299,8 @@ namespace System.Windows.Controls
         /// </summary>
         public event RoutedPropertyChangingEventHandler<bool> DropDownOpening
         {
-            add { AddHandler(PopulatedEvent, value); }
-            remove { RemoveHandler(PopulatedEvent, value); }
+            add { AddHandler(DropDownOpeningEvent, value); }
+            remove { RemoveHandler(DropDownOpeningEvent, value); }
         }
 #endif
 


### PR DESCRIPTION
When using the DropDownOpening event an ArgumentException (not 100% sure about the type) with the message "Handler type is mismatched". The exception arises because the wrong event type "PopulatedEvent" is used instead of "DropDownOpeningEvent".

The behaviour can be tested by adding an AutoCompleteBox to a Xaml-Element (e.g. Window, UserControl) and registering adding a handler to the "DropDownOpeningEvent".

<input:AutoCompleteBox x:Name="TestAutoCompleteBox" DropDownOpening="TestAutoCompleteBox_DropDownOpening" />

Running this Xaml-Code results in the described error.